### PR TITLE
Remove expired link to code.google.com

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,6 @@ The userspace side is developed in systemd:
 
 Development repos:
   https://github.com/gregkh/kdbus
-  https://code.google.com/p/d-bus/
 
 See also:
   https://review.tizen.org/git/?p=platform/upstream/glib.git;a=shortlog;h=refs/heads/kdbus-integration


### PR DESCRIPTION
code.google.com's free hosting for open source projects was terminated
Jan 25, 2016.  Since this repository is no longer valid, remove the link.
